### PR TITLE
Fix user page in admin page

### DIFF
--- a/wlm_server/team/models.py
+++ b/wlm_server/team/models.py
@@ -2,3 +2,6 @@ from django.db import models
 
 class Team(models.Model):
     name = models.CharField(max_length=30, unique=True)
+
+    def __str__(self):
+        return self.name

--- a/wlm_server/user/admin.py
+++ b/wlm_server/user/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.admin import UserAdmin
 from .models import User
 
 @admin.register(User)
-class UserAdmin_(UserAdmin):
+class CustomUserAdmin(UserAdmin):
     fieldsets = [
         (
             None,

--- a/wlm_server/user/admin.py
+++ b/wlm_server/user/admin.py
@@ -3,4 +3,31 @@ from django.contrib.auth.admin import UserAdmin
 
 from .models import User
 
-admin.site.register(User, UserAdmin)
+@admin.register(User)
+class UserAdmin_(UserAdmin):
+    fieldsets = [
+        (
+            None,
+            {
+                'fields': ['username', 'password', 'team'],
+            },
+        ),
+        (
+            'Advanced options',
+            {
+                'classes': ['collapse'],
+                'fields': ['is_superuser'],
+            },
+        ),
+        (
+            'Important dates',
+            {
+                'classes': ['collapse'],
+                'fields': ['last_login'],
+            },
+        ),
+    ]
+    list_display = ('username', 'id', 'team__name', 'is_superuser')
+    list_filter = ('team__name', 'is_superuser')
+    search_fields = ('username', 'team__name')
+    ordering = ('id',)

--- a/wlm_server/user/admin.py
+++ b/wlm_server/user/admin.py
@@ -27,7 +27,8 @@ class CustomUserAdmin(UserAdmin):
             },
         ),
     ]
-    list_display = ('username', 'id', 'team__name', 'is_superuser')
-    list_filter = ('team__name', 'is_superuser')
-    search_fields = ('username', 'team__name')
-    ordering = ('id',)
+    list_display = ['username', 'id', 'team__name', 'is_superuser']
+    list_filter = ['team__name', 'is_superuser']
+    search_fields = ['username', 'team__name']
+    ordering = ['id']
+    readonly_fields = ['last_login']


### PR DESCRIPTION
This resolves #11. For details, please read the issue.

A user list page is as follows.

![image](https://github.com/user-attachments/assets/f10d9eaf-0f84-46a8-9c6b-9ed03e2fd88d)


A user detail page is as shown below.

![image](https://github.com/user-attachments/assets/00216309-c82a-4a02-8368-08d79800eeae)
