### PR TITLE
Offer channels info

### DIFF
--- a/wlm_server/channel/serializer.py
+++ b/wlm_server/channel/serializer.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+from .models import Channel
+
+class ChannelInfoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Channel
+        fields = (
+            'channel',
+            'name',
+        )

--- a/wlm_server/channel/urls.py
+++ b/wlm_server/channel/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.handle_info, name='handle channels info'),
+]

--- a/wlm_server/channel/views.py
+++ b/wlm_server/channel/views.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.decorators import login_required
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+
+from channel.models import Channel
+from channel.serializer import ChannelInfoSerializer
+
+@login_required
+@api_view(['GET'])
+def handle_info(request):
+    user = request.user
+    channels = Channel.objects.filter(teams=user.team)
+    data = ChannelInfoSerializer(channels, many=True).data
+    return Response(data)

--- a/wlm_server/team/serializer.py
+++ b/wlm_server/team/serializer.py
@@ -6,6 +6,6 @@ class TeamInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = Team
         fields = (
-            "id",
-            "name",
+            'id',
+            'name',
         )

--- a/wlm_server/user/serializer.py
+++ b/wlm_server/user/serializer.py
@@ -9,8 +9,8 @@ class UserInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (
-            "id",
-            "username",
-            "password",
-            "team",
+            'id',
+            'username',
+            'password',
+            'team',
         )

--- a/wlm_server/user/views.py
+++ b/wlm_server/user/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from rest_framework.response import Response
@@ -32,4 +32,4 @@ def sign_out(request):
 def handle_info(request):
     user = request.user
     data = UserInfoSerializer(user).data
-    return JsonResponse(data)
+    return Response(data)

--- a/wlm_server/wlm_server/urls.py
+++ b/wlm_server/wlm_server/urls.py
@@ -19,5 +19,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path('user/', include('user.urls')),
+    path('channel/', include('channel.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
This resolves #8.

I implemented the feature to offer available channels info with the url `/channel/`.

One can test it using the codes below.

```python
import requests

BASE_URL = 'http://localhost:8000'

with requests.Session() as session:
    data = {'username': 'jaehun', 'password': 'dbwogns01!'}
    response = session.post(BASE_URL + '/user/signin/', data=data)
    print(response.status_code)  # 200

    csrf_token = session.cookies.get('csrftoken')
    headers = {'X-CSRFToken': csrf_token}

    response = session.get(BASE_URL + '/channel/', headers=headers)
    print(response.json())  # [{'channel': 1, 'name': 'CH 1'}, {'channel': 2, 'name': 'CH 2'}]

    response = session.post(BASE_URL + '/user/signout/', headers=headers)
    print(response.status_code)  # 200
```