### PR TITLE
Use PostgreSQL for DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+.pgpass
 
 # Flask stuff:
 instance/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-decouple==3.8
 pylint==3.3.*
 pylint-django==2.6.*
 djangorestframework==3.15.*
+psycopg==3.2.*

--- a/wlm_server/setting/migrations/0002_alter_setting_exposure.py
+++ b/wlm_server/setting/migrations/0002_alter_setting_exposure.py
@@ -10,6 +10,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            "ALTER TABLE setting_setting ALTER COLUMN exposure TYPE INTERVAL USING (exposure * INTERVAL '1 second');",
+            reverse_sql='ALTER TABLE setting_setting ALTER COLUMN exposure TYPE DOUBLE PRECISION USING (extract(epoch from exposure));'
+        ),
         migrations.AlterField(
             model_name='setting',
             name='exposure',

--- a/wlm_server/wlm_server/settings.py
+++ b/wlm_server/wlm_server/settings.py
@@ -90,8 +90,11 @@ WSGI_APPLICATION = 'wlm_server.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'OPTIONS': {
+            'service': config('POSTGRESQL_SERVICE', default='TEST_POSTGRESQL_SERVICE'),
+            'passfile': '.pgpass',
+        },
     }
 }
 


### PR DESCRIPTION
This resolves #28.

To integrate PostgreSQL DB, one can follow the steps as below.
1. Install [PostgreSQL](https://www.postgresql.org/download/). It would create an OS user named `postgres` and run DB server in a daemon mode.
2. Access the DB manager using `psql` command. You should use the `postgres` user to gain permission.
3. Create a DB (Its name will be indicated in service file.) and a user.
4. Grant all permissions to the user for the DB.
5. Update `pg_hba.conf` file to allow the current OS user to access the PostgreSQL DB.
6. Make service and password files referred to [Django](https://docs.djangoproject.com/en/5.1/ref/databases/#postgresql-notes).
7. Migrate the Django server.
8. Run the server.