### PR TITLE
Notify channel operation change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+daphne==4.1.*
 Django==5.1.*
 python-decouple==3.8
 pylint==3.3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pylint==3.3.*
 pylint-django==2.6.*
 djangorestframework==3.15.*
 psycopg==3.2.*
+channels==4.2.*
 pylablib==1.4.*
 camel-converter==4.0.*

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -19,5 +19,13 @@ class OperationConsumer(AsyncWebsocketConsumer):
         await self.channel_layer.group_discard(self.group_name, self.channel_name)
 
     async def notify(self, event: dict[str, str]):
+        """Notifies the operation change to the channels that belong to the same group.
+        
+        Args:
+            event: Dictionary with two keys.
+              type: Please refer to the documentation of Channels.
+              message: Dictionary with one key.
+                on: Updated operation status.
+        """
         message = event['message']
         await self.send(text_data=message)

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -14,3 +14,6 @@ class OperationConsumer(AsyncWebsocketConsumer):
         self.group_name = f'channel_{self.ch}'
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self.accept()
+
+    async def disconnect(self, code):
+        await self.channel_layer.group_discard(self.group_name, self.channel_name)

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -1,4 +1,8 @@
+import json
+
 from channels.generic.websocket import AsyncWebsocketConsumer
+
+from utils import util
 
 class OperationConsumer(AsyncWebsocketConsumer):
     """Consumer for notifying the operation change of a specific channel.
@@ -14,6 +18,7 @@ class OperationConsumer(AsyncWebsocketConsumer):
         self.group_name = f'channel_{self.ch}_operation'
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self.accept()
+        await self.send(text_data=json.dumps({'on': util.is_channel_running(self.ch)}))
 
     async def disconnect(self, code):
         await self.channel_layer.group_discard(self.group_name, self.channel_name)

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -1,5 +1,3 @@
-import json
-
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 class OperationConsumer(AsyncWebsocketConsumer):

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -1,3 +1,5 @@
+import json
+
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 class OperationConsumer(AsyncWebsocketConsumer):
@@ -17,3 +19,7 @@ class OperationConsumer(AsyncWebsocketConsumer):
 
     async def disconnect(self, code):
         await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def notify(self, event: dict[str, str]):
+        message = event['message']
+        await self.send(text_data=message)

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -1,0 +1,16 @@
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+class OperationConsumer(AsyncWebsocketConsumer):
+    """Consumer for notifying the operation change of a specific channel.
+    
+    Attributes:
+        ch: Target WLM channel.
+        group_name: Name of group it belongs to in the channel layer.
+    """
+
+    # pylint: disable=attribute-defined-outside-init
+    async def connect(self):
+        self.ch = self.scope['url_route']['kwargs']['ch']
+        self.group_name = f'channel_{self.ch}'
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()

--- a/wlm_server/operation/consumers.py
+++ b/wlm_server/operation/consumers.py
@@ -11,7 +11,7 @@ class OperationConsumer(AsyncWebsocketConsumer):
     # pylint: disable=attribute-defined-outside-init
     async def connect(self):
         self.ch = self.scope['url_route']['kwargs']['ch']
-        self.group_name = f'channel_{self.ch}'
+        self.group_name = f'channel_{self.ch}_operation'
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self.accept()
 

--- a/wlm_server/operation/views.py
+++ b/wlm_server/operation/views.py
@@ -37,7 +37,7 @@ def handle_info(request, ch: int):
             notif = {'on': True}
             channel_layer = get_channel_layer()
             async_to_sync(channel_layer.group_send)(
-                f'channel_{ch}', {'type': 'notify', 'message': json.dumps(notif)}
+                f'channel_{ch}_operation', {'type': 'notify', 'message': json.dumps(notif)}
             )
         operation.save()
     else:
@@ -48,7 +48,7 @@ def handle_info(request, ch: int):
             notif = {'on': False}
             channel_layer = get_channel_layer()
             async_to_sync(channel_layer.group_send)(
-                f'channel_{ch}', {'type': 'notify', 'message': json.dumps(notif)}
+                f'channel_{ch}_operation', {'type': 'notify', 'message': json.dumps(notif)}
             )
         if not util.is_wlm_running():
             message = MessageInfo(ActionType.CLOSE, None, None)

--- a/wlm_server/operation/views.py
+++ b/wlm_server/operation/views.py
@@ -1,7 +1,11 @@
+import json
+
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from rest_framework.decorators import api_view
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
 
 from operation.models import Operation
 from channel.models import Channel
@@ -27,6 +31,11 @@ def handle_info(request, ch: int):
         if not util.is_wlm_running():
             task_handler = TaskHandler()
             task_handler.start()
+            notif = {'on': True}
+            channel_layer = get_channel_layer()
+            async_to_sync(channel_layer.group_send)(
+                f'channel_{ch}', {'type': 'notify', 'message': json.dumps(notif)}
+            )
         if not util.is_channel_running(ch):
             message = MessageInfo(ActionType.OPERATE, ch, {'on': True})
             message_queue.push(message)
@@ -39,4 +48,9 @@ def handle_info(request, ch: int):
         if not util.is_wlm_running():
             message = MessageInfo(ActionType.CLOSE, None, None)
             message_queue.push(message)
+            notif = {'on': False}
+            channel_layer = get_channel_layer()
+            async_to_sync(channel_layer.group_send)(
+                f'channel_{ch}', {'type': 'notify', 'message': json.dumps(notif)}
+            )
     return HttpResponse(status=200)

--- a/wlm_server/operation/views.py
+++ b/wlm_server/operation/views.py
@@ -31,26 +31,26 @@ def handle_info(request, ch: int):
         if not util.is_wlm_running():
             task_handler = TaskHandler()
             task_handler.start()
+        if not util.is_channel_running(ch):
+            message = MessageInfo(ActionType.OPERATE, ch, {'on': True})
+            message_queue.push(message)
             notif = {'on': True}
             channel_layer = get_channel_layer()
             async_to_sync(channel_layer.group_send)(
                 f'channel_{ch}', {'type': 'notify', 'message': json.dumps(notif)}
             )
-        if not util.is_channel_running(ch):
-            message = MessageInfo(ActionType.OPERATE, ch, {'on': True})
-            message_queue.push(message)
         operation.save()
     else:
         operation.save()
         if not util.is_channel_running(ch):
             message = MessageInfo(ActionType.OPERATE, ch, {'on': False})
             message_queue.push(message)
-        if not util.is_wlm_running():
-            message = MessageInfo(ActionType.CLOSE, None, None)
-            message_queue.push(message)
             notif = {'on': False}
             channel_layer = get_channel_layer()
             async_to_sync(channel_layer.group_send)(
                 f'channel_{ch}', {'type': 'notify', 'message': json.dumps(notif)}
             )
+        if not util.is_wlm_running():
+            message = MessageInfo(ActionType.CLOSE, None, None)
+            message_queue.push(message)
     return HttpResponse(status=200)

--- a/wlm_server/wlm_server/asgi.py
+++ b/wlm_server/wlm_server/asgi.py
@@ -11,6 +11,7 @@ import os
 
 from django.core.asgi import get_asgi_application
 from django.urls import path
+from django.conf import settings
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
@@ -18,7 +19,10 @@ from channels.security.websocket import AllowedHostsOriginValidator
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
 
 # pylint: disable=wrong-import-position
+from cache.channel import ChannelCache
 from operation.consumers import OperationConsumer
+
+settings.CHANNEL_CACHE = ChannelCache()
 
 application = ProtocolTypeRouter(
     {

--- a/wlm_server/wlm_server/asgi.py
+++ b/wlm_server/wlm_server/asgi.py
@@ -10,7 +10,19 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
 
-application = get_asgi_application()
+application = ProtocolTypeRouter(
+    {
+        'http': get_asgi_application(),
+        'websocket': AllowedHostsOriginValidator(
+            AuthMiddlewareStack(
+                URLRouter([])
+            )
+        ),
+    }
+)

--- a/wlm_server/wlm_server/asgi.py
+++ b/wlm_server/wlm_server/asgi.py
@@ -10,18 +10,24 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
+from django.urls import path
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
 
+# pylint: disable=wrong-import-position
+from operation.consumers import OperationConsumer
+
 application = ProtocolTypeRouter(
     {
         'http': get_asgi_application(),
         'websocket': AllowedHostsOriginValidator(
             AuthMiddlewareStack(
-                URLRouter([])
+                URLRouter([
+                    path('ws/operation/<int:ch>/', OperationConsumer.as_asgi()),
+                ])
             )
         ),
     }

--- a/wlm_server/wlm_server/settings.py
+++ b/wlm_server/wlm_server/settings.py
@@ -35,6 +35,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'daphne',
     'channels',
     'django.contrib.admin',
     'django.contrib.auth',

--- a/wlm_server/wlm_server/settings.py
+++ b/wlm_server/wlm_server/settings.py
@@ -35,6 +35,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'channels',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -82,7 +83,15 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'wlm_server.wsgi.application'
+ASGI_APPLICATION = 'wlm_server.asgi.application'
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    },
+}
+
+AUTH_USER_MODEL = 'user.User'
 
 
 # Database
@@ -140,7 +149,8 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-AUTH_USER_MODEL = 'user.User'
+
+# Global variables
 
 MESSAGE_QUEUE = MessageQueue()
 

--- a/wlm_server/wlm_server/wsgi.py
+++ b/wlm_server/wlm_server/wsgi.py
@@ -9,10 +9,7 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/wsgi/
 
 import os
 
-from django.conf import settings
 from django.core.wsgi import get_wsgi_application
-
-from cache.channel import ChannelCache
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
 

--- a/wlm_server/wlm_server/wsgi.py
+++ b/wlm_server/wlm_server/wsgi.py
@@ -16,6 +16,4 @@ from cache.channel import ChannelCache
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
 
-settings.CHANNEL_CACHE = ChannelCache()
-
 application = get_wsgi_application()


### PR DESCRIPTION
*(The issue #34 was completed, thus I recreate this PR.)*

This is a half part of #17. Before you start to review, please read the issue carefully.

I implemented only the feature in terms of the channel operation change.

The main features are as follows.
- Use ASGI instead of WSGI (default). For this, I utilized the `daphne` server, which is the recommended server for `Channels`.
- Use `Channels` to implemented WebSockets.

To test this, one can use the codes below.
#### Client 1: Listen to the operation change
```python
import requests
from websockets.sync.client import connect

HTTP_BASE_URL = 'http://localhost:8000'
WS_BASE_URL = 'ws://localhost:8000'

with requests.Session() as session:
    data = {'username': 'OOOO', 'password': 'OOOO'}
    response = session.post(HTTP_BASE_URL + '/user/signin/', json=data)

    csrf_token = session.cookies.get('csrftoken')
    headers = {'X-CSRFToken': csrf_token}

    with connect(WS_BASE_URL + '/ws/operation/1/', origin='http://localhost:3000') as websocket:
        while True:
            response = websocket.recv()
            print(response)  # {"on": true} or {"on": false}
```

#### Client 2: Update the operation status
```python
import time

import requests

HTTP_BASE_URL = 'http://localhost:8000'

with requests.Session() as session:
    data = {'username': 'OOOO', 'password': 'OOOO'}
    response = session.post(HTTP_BASE_URL + '/user/signin/', json=data)

    csrf_token = session.cookies.get('csrftoken')
    headers = {'X-CSRFToken': csrf_token}

    response = session.post(HTTP_BASE_URL + '/operation/1/', json={'on': True}, headers=headers)
    time.sleep(1)

    response = session.post(HTTP_BASE_URL + '/operation/1/', json={'on': False}, headers=headers)
    time.sleep(1)

    response = session.post(HTTP_BASE_URL + '/operation/1/', json={'on': True}, headers=headers)
    time.sleep(1)

    response = session.post(HTTP_BASE_URL + '/operation/1/', json={'on': False}, headers=headers)
    time.sleep(1)

    response = session.post(HTTP_BASE_URL + '/operation/1/', json={'on': True}, headers=headers)
    time.sleep(1)

    response = session.post(HTTP_BASE_URL + '/operation/1/', json={'on': False}, headers=headers)
    time.sleep(1)

    response = session.post(HTTP_BASE_URL + '/user/signout/', headers=headers)
```