### PR TITLE
Offer single channel info

### DIFF
--- a/wlm_server/channel/urls.py
+++ b/wlm_server/channel/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.handle_info, name='handle channels info'),
+    path('<int:ch>/', views.handle_single_info, name='handle single channel info'),
 ]

--- a/wlm_server/channel/views.py
+++ b/wlm_server/channel/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import require_http_methods
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from camel_converter import dict_to_camel
@@ -9,6 +10,7 @@ from channel.serializers import ChannelInfoSerializer
 from utils import util
 
 @login_required
+@require_http_methods(['GET'])
 @api_view(['GET'])
 def handle_info(request):
     user = request.user
@@ -18,6 +20,7 @@ def handle_info(request):
 
 
 @login_required
+@require_http_methods(['GET'])
 @api_view(['GET'])
 def handle_single_info(request, ch: int):
     user = request.user

--- a/wlm_server/channel/views.py
+++ b/wlm_server/channel/views.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
@@ -5,6 +6,7 @@ from camel_converter import dict_to_camel
 
 from channel.models import Channel
 from channel.serializers import ChannelInfoSerializer
+from utils import util
 
 @login_required
 @api_view(['GET'])
@@ -13,3 +15,14 @@ def handle_info(request):
     channels = Channel.objects.filter(teams=user.team)
     data = ChannelInfoSerializer(channels, many=True, context={'username': user.username}).data
     return Response([dict_to_camel(info) for info in data])
+
+
+@login_required
+@api_view(['GET'])
+def handle_single_info(request, ch: int):
+    user = request.user
+    channel, error_code = util.verify_channel_access(user, ch, False)
+    if channel is None:
+        return HttpResponse(status=error_code)
+    data = ChannelInfoSerializer(channel, context={'username': user.username}).data
+    return Response(dict_to_camel(data))


### PR DESCRIPTION
This resolves #42.

This issue was designed for a separate channel viewer page.
We decided not to develop the feature, so there is no necessity to merge it.
However, I think this is too simple feature and might be used later, thus I'm requesting this PR.