### PR TITLE
Not load previous operation status when server is started

### DIFF
--- a/wlm_server/cache/channel.py
+++ b/wlm_server/cache/channel.py
@@ -22,11 +22,6 @@ class ChannelCache:
 
     def _load(self):
         """Loads all channels status."""
-        operations = (Operation.objects.order_by('channel', 'user', '-occurred_at')
-                      .distinct('channel', 'user'))
-        for operation in operations:
-            (self._channel_to_operation
-             [operation.channel.channel][operation.user.username]) = operation
         settings = Setting.objects.order_by('channel', '-created_at').distinct('channel')
         for setting in settings:
             self._channel_to_setting[setting.channel.channel] = setting


### PR DESCRIPTION
This resolves #44.