### PR TITLE
Support deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .venv
 env/
 venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pylint-django==2.6.*
 djangorestframework==3.15.*
 psycopg==3.2.*
 channels==4.2.*
+whitenoise==6.8.*
 pylablib==1.4.*
 camel-converter==4.0.*

--- a/wlm_server/.gitignore
+++ b/wlm_server/.gitignore
@@ -1,0 +1,2 @@
+# Static files
+/staticfiles

--- a/wlm_server/manage.py
+++ b/wlm_server/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings.development')
     try:
         from django.core.management import execute_from_command_line  # pylint: disable=import-outside-toplevel
     except ImportError as exc:

--- a/wlm_server/task/wlm.py
+++ b/wlm_server/task/wlm.py
@@ -1,1 +1,0 @@
-"""Module for communication with WLM."""

--- a/wlm_server/wlm_server/asgi.py
+++ b/wlm_server/wlm_server/asgi.py
@@ -16,7 +16,7 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings.production')
 
 # pylint: disable=wrong-import-position
 from cache.channel import ChannelCache

--- a/wlm_server/wlm_server/asgi.py
+++ b/wlm_server/wlm_server/asgi.py
@@ -18,6 +18,8 @@ from channels.security.websocket import AllowedHostsOriginValidator
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wlm_server.settings.production')
 
+asgi_application = get_asgi_application()
+
 # pylint: disable=wrong-import-position
 from cache.channel import ChannelCache
 from operation.consumers import OperationConsumer
@@ -30,7 +32,7 @@ settings.CHANNEL_CACHE = ChannelCache()
 
 application = ProtocolTypeRouter(
     {
-        'http': get_asgi_application(),
+        'http': asgi_application,
         'websocket': AllowedHostsOriginValidator(
             AuthMiddlewareStack(
                 URLRouter([

--- a/wlm_server/wlm_server/settings/base.py
+++ b/wlm_server/wlm_server/settings/base.py
@@ -24,14 +24,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config('SECRET_KEY', default='TEST_SECRET_KEY')
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -103,7 +95,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'OPTIONS': {
-            'service': config('POSTGRESQL_SERVICE', default='TEST_POSTGRESQL_SERVICE'),
+            'service': config('POSTGRESQL_SERVICE'),
             'passfile': '.pgpass',
         },
     }

--- a/wlm_server/wlm_server/settings/base.py
+++ b/wlm_server/wlm_server/settings/base.py
@@ -28,7 +28,7 @@ else:
 config = Config(RepositoryEnv(env_path))
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 # Quick-start development settings - unsuitable for production
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -147,6 +148,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = 'static/'
+
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field

--- a/wlm_server/wlm_server/settings/base.py
+++ b/wlm_server/wlm_server/settings/base.py
@@ -10,12 +10,22 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+import os
 import threading
 from pathlib import Path
 
-from decouple import config
+from decouple import Config, RepositoryEnv
 
 from task.message import MessageQueue
+
+settings_module = os.getenv('DJANGO_SETTINGS_MODULE')
+if settings_module == 'wlm_server.settings.development':
+    env_path = '.env.development'
+elif settings_module == 'wlm_server.settings.production':
+    env_path = '.env.production'
+else:
+    raise ValueError('Invalid DJANGO_SETTINGS_MODULE')
+config = Config(RepositoryEnv(env_path))
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/wlm_server/wlm_server/settings/base.py
+++ b/wlm_server/wlm_server/settings/base.py
@@ -20,12 +20,12 @@ from task.message import MessageQueue
 
 settings_module = os.getenv('DJANGO_SETTINGS_MODULE')
 if settings_module == 'wlm_server.settings.development':
-    env_path = '.env.development'
+    ENV_PATH = '.env.development'
 elif settings_module == 'wlm_server.settings.production':
-    env_path = '.env.production'
+    ENV_PATH = '.env.production'
 else:
     raise ValueError('Invalid DJANGO_SETTINGS_MODULE')
-config = Config(RepositoryEnv(env_path))
+config = Config(RepositoryEnv(ENV_PATH))
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent

--- a/wlm_server/wlm_server/settings/development.py
+++ b/wlm_server/wlm_server/settings/development.py
@@ -1,5 +1,3 @@
-from decouple import config
-
 from .base import *
 
 SECRET_KEY = 'TEST_SECRET_KEY'

--- a/wlm_server/wlm_server/settings/development.py
+++ b/wlm_server/wlm_server/settings/development.py
@@ -1,0 +1,7 @@
+from decouple import config
+
+from .base import *
+
+SECRET_KEY = 'TEST_SECRET_KEY'
+
+DEBUG = True

--- a/wlm_server/wlm_server/settings/development.py
+++ b/wlm_server/wlm_server/settings/development.py
@@ -1,4 +1,4 @@
-from .base import *
+from .base import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 SECRET_KEY = 'TEST_SECRET_KEY'
 

--- a/wlm_server/wlm_server/settings/production.py
+++ b/wlm_server/wlm_server/settings/production.py
@@ -1,5 +1,3 @@
-from decouple import config
-
 from .base import *
 
 SECRET_KEY = config('SECRET_KEY')

--- a/wlm_server/wlm_server/settings/production.py
+++ b/wlm_server/wlm_server/settings/production.py
@@ -5,3 +5,6 @@ SECRET_KEY = config('SECRET_KEY')
 DEBUG = False
 
 ALLOWED_HOSTS = ['localhost', config('SERVER_IP')]
+
+CSRF_TRUSTED_ORIGINS = [
+    'https://localhost', f'https://{config('SERVER_IP')}']

--- a/wlm_server/wlm_server/settings/production.py
+++ b/wlm_server/wlm_server/settings/production.py
@@ -1,4 +1,4 @@
-from .base import *
+from .base import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 SECRET_KEY = config('SECRET_KEY')
 
@@ -6,5 +6,4 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['localhost', config('SERVER_IP')]
 
-CSRF_TRUSTED_ORIGINS = [
-    'https://localhost', f'https://{config('SERVER_IP')}']
+CSRF_TRUSTED_ORIGINS = ['https://localhost', f'https://{config("SERVER_IP")}']

--- a/wlm_server/wlm_server/settings/production.py
+++ b/wlm_server/wlm_server/settings/production.py
@@ -1,0 +1,9 @@
+from decouple import config
+
+from .base import *
+
+SECRET_KEY = config('SECRET_KEY')
+
+DEBUG = False
+
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']

--- a/wlm_server/wlm_server/settings/production.py
+++ b/wlm_server/wlm_server/settings/production.py
@@ -4,4 +4,4 @@ SECRET_KEY = config('SECRET_KEY')
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+ALLOWED_HOSTS = ['localhost', config('SERVER_IP')]

--- a/wlm_server/wlm_server/urls.py
+++ b/wlm_server/wlm_server/urls.py
@@ -18,11 +18,11 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path('user/', include('user.urls')),
-    path('channel/', include('channel.urls')),
-    path('setting/', include('setting.urls')),
-    path('operation/', include('operation.urls')),
-    path('calibration/', include('calibration.urls')),
-    path('lock/', include('lock.urls')),
+    path('api/user/', include('user.urls')),
+    path('api/channel/', include('channel.urls')),
+    path('api/setting/', include('setting.urls')),
+    path('api/operation/', include('operation.urls')),
+    path('api/calibration/', include('calibration.urls')),
+    path('api/lock/', include('lock.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
This resolves #47.

Now one can run the server on both development and production mode:
```shell
# development mode (existing method)
python manage.py runserver

# production mode
daphne -b 0.0.0.0 -p 8000 wlm_server.asgi:application
```