### PR TITLE
More efficient data acquisition

### DIFF
--- a/wlm_server/measurement/consumers.py
+++ b/wlm_server/measurement/consumers.py
@@ -45,7 +45,7 @@ class MeasurementConsumer(AsyncWebsocketConsumer):
         Args:
             event: Dictionary with two keys.
               type: Please refer to the documentation of Channels.
-              message: Dictionary with three keys.
+              message: List of dictionaries with three keys.
                 frequency: Measured frequency in Hz. If an error occurs, it is set to None.
                 error: Occurred error code. Please refer to the documentation of pylablib. If no
                   error occurs, it is set to None.

--- a/wlm_server/task/handler.py
+++ b/wlm_server/task/handler.py
@@ -22,7 +22,7 @@ from .measure import MeasureInfo, MeasureQueue
 MEASUREMENT_SLICE_SECONDS = 0.5
 
 
-class TaskHandler(threading.Thread):  # pylint: disable=too-many-locals
+class TaskHandler(threading.Thread):
     """Task handler for controlling and monitoring WLM.
     
     Workflow:
@@ -77,7 +77,7 @@ class TaskHandler(threading.Thread):  # pylint: disable=too-many-locals
     def _calibrate(self, channel: int, frequency: float):
         self._wlm.calibrate(source_type='other', source_frequency=frequency, channel=channel)
 
-    def run(self):
+    def run(self):  # pylint: disable=too-many-locals
         while True:
             while (message := self._message_queue.pop()) is not None:
                 channel = message.channel

--- a/wlm_server/task/handler.py
+++ b/wlm_server/task/handler.py
@@ -22,7 +22,7 @@ from .measure import MeasureInfo, MeasureQueue
 MEASUREMENT_SLICE_SECONDS = 0.5
 
 
-class TaskHandler(threading.Thread):
+class TaskHandler(threading.Thread):  # pylint: disable=too-many-locals
     """Task handler for controlling and monitoring WLM.
     
     Workflow:

--- a/wlm_server/task/handler.py
+++ b/wlm_server/task/handler.py
@@ -1,5 +1,6 @@
 """Module for task handler with WLM."""
 
+import time
 import threading
 import json
 from datetime import timedelta
@@ -16,6 +17,9 @@ from setting.models import Setting
 from measurement.models import Measurement
 from .message import ActionType, MessageQueue
 from .measure import MeasureInfo, MeasureQueue
+
+MEASUREMENT_SLICE_SECONDS = 0.5
+
 
 class TaskHandler(threading.Thread):
     """Task handler for controlling and monitoring WLM.
@@ -99,28 +103,32 @@ class TaskHandler(threading.Thread):
                     case ActionType.CALIB:
                         self._set_channel_exposure(channel, data['exposure'])
                         self._calibrate(channel, data['freq'])
-            measure = self._measure_queue.pop()
-            if measure is None:
-                continue
-            channel = measure.channel
-            self._switch(channel)
-            frequency_or_error = self._wlm.get_frequency(
-                channel=channel, error_on_invalid=False, wait=True, timeout=3)
-            setting = self._channel_to_setting[channel]
-            deadline = timezone.now() + setting.period
-            next_measure = MeasureInfo(channel, deadline)
-            self._measure_queue.push(next_measure)
-            notif = {'frequency': None, 'error': None}
-            if isinstance(frequency_or_error, float):
-                measure_record = Measurement(setting=setting, frequency=frequency_or_error)
-                notif['frequency'] = frequency_or_error
-            else:
-                measure_record = Measurement(setting=setting, error=frequency_or_error)
-                notif['error'] = frequency_or_error
-            measure_record.save()
-            notif['measured_at'] = measure_record.measured_at.isoformat()
+            notif = []
+            measurement_slice_deadline = time.monotonic() + MEASUREMENT_SLICE_SECONDS
+            while time.monotonic() < measurement_slice_deadline:
+                measure = self._measure_queue.pop()
+                if measure is None:
+                    continue
+                channel = measure.channel
+                self._switch(channel)
+                frequency_or_error = self._wlm.get_frequency(
+                    channel=channel, error_on_invalid=False, wait=True, timeout=3)
+                setting = self._channel_to_setting[channel]
+                deadline = timezone.now() + setting.period
+                next_measure = MeasureInfo(channel, deadline)
+                self._measure_queue.push(next_measure)
+                measurement = {'frequency': None, 'error': None}
+                if isinstance(frequency_or_error, float):
+                    measure_record = Measurement(setting=setting, frequency=frequency_or_error)
+                    measurement['frequency'] = frequency_or_error
+                else:
+                    measure_record = Measurement(setting=setting, error=frequency_or_error)
+                    measurement['error'] = frequency_or_error
+                measure_record.save()
+                measurement['measured_at'] = measure_record.measured_at.isoformat()
+                notif.append(dict_to_camel(measurement))
             channel_layer = get_channel_layer()
             async_to_sync(channel_layer.group_send)(
                 f'channel_{channel}_measurement',
-                {'type': 'notify', 'message': json.dumps(dict_to_camel(notif))}
+                {'type': 'notify', 'message': json.dumps(notif)}
             )

--- a/wlm_server/task/handler.py
+++ b/wlm_server/task/handler.py
@@ -3,6 +3,7 @@
 import time
 import threading
 import json
+from collections import defaultdict
 from datetime import timedelta
 
 from django.utils import timezone
@@ -103,7 +104,7 @@ class TaskHandler(threading.Thread):
                     case ActionType.CALIB:
                         self._set_channel_exposure(channel, data['exposure'])
                         self._calibrate(channel, data['freq'])
-            notif = []
+            measurements: dict[int, list] = defaultdict(list)  # {channel: [measurement]}
             measurement_slice_deadline = time.monotonic() + MEASUREMENT_SLICE_SECONDS
             while time.monotonic() < measurement_slice_deadline:
                 measure = self._measure_queue.pop()
@@ -126,9 +127,10 @@ class TaskHandler(threading.Thread):
                     measurement['error'] = frequency_or_error
                 measure_record.save()
                 measurement['measured_at'] = measure_record.measured_at.isoformat()
-                notif.append(dict_to_camel(measurement))
+                measurements[channel].append(dict_to_camel(measurement))
             channel_layer = get_channel_layer()
-            async_to_sync(channel_layer.group_send)(
-                f'channel_{channel}_measurement',
-                {'type': 'notify', 'message': json.dumps(notif)}
-            )
+            for channel, channel_measurements in measurements.items():
+                async_to_sync(channel_layer.group_send)(
+                    f'channel_{channel}_measurement',
+                    {'type': 'notify', 'message': json.dumps(channel_measurements)}
+                )

--- a/wlm_server/task/handler.py
+++ b/wlm_server/task/handler.py
@@ -5,6 +5,7 @@ import threading
 import json
 from collections import defaultdict
 from datetime import timedelta
+from typing import Any
 
 from django.utils import timezone
 from django.conf import settings
@@ -28,9 +29,10 @@ class TaskHandler(threading.Thread):
     Workflow:
         1. Check if there are remaining messages in message queue. If so, perform all tasks.
         2. Get the most prioritized measurement from measurement queue.
-        3. Perform the measurement and notify the result to request handler.
-        4. Put the next measurement to measurement queue.
-        5. Repeat steps 1 through 4.
+        3. Perform the measurement and record the result.
+        4. Repeat steps 2 and 3 for measurement slice.
+        5. Notify all results to request handlers.
+        6. Repeat steps 1 through 5.
     """
 
     def __init__(self):
@@ -74,6 +76,24 @@ class TaskHandler(threading.Thread):
             self._wlm.set_active_channel(channel=channel)
             self._active_channel = channel
 
+    def _measure_channel(self, channel: int) -> dict[str, Any]:
+        frequency_or_error = self._wlm.get_frequency(
+            channel=channel, error_on_invalid=False, wait=True, timeout=3)
+        setting = self._channel_to_setting[channel]
+        deadline = timezone.now() + setting.period
+        next_measure = MeasureInfo(channel, deadline)
+        self._measure_queue.push(next_measure)
+        measurement = {'frequency': None, 'error': None}
+        if isinstance(frequency_or_error, float):
+            measure_record = Measurement(setting=setting, frequency=frequency_or_error)
+            measurement['frequency'] = frequency_or_error
+        else:
+            measure_record = Measurement(setting=setting, error=frequency_or_error)
+            measurement['error'] = frequency_or_error
+        measure_record.save()
+        measurement['measured_at'] = measure_record.measured_at.isoformat()
+        return dict_to_camel(measurement)
+
     def _calibrate(self, channel: int, frequency: float):
         self._wlm.calibrate(source_type='other', source_frequency=frequency, channel=channel)
 
@@ -112,22 +132,8 @@ class TaskHandler(threading.Thread):
                     continue
                 channel = measure.channel
                 self._switch(channel)
-                frequency_or_error = self._wlm.get_frequency(
-                    channel=channel, error_on_invalid=False, wait=True, timeout=3)
-                setting = self._channel_to_setting[channel]
-                deadline = timezone.now() + setting.period
-                next_measure = MeasureInfo(channel, deadline)
-                self._measure_queue.push(next_measure)
-                measurement = {'frequency': None, 'error': None}
-                if isinstance(frequency_or_error, float):
-                    measure_record = Measurement(setting=setting, frequency=frequency_or_error)
-                    measurement['frequency'] = frequency_or_error
-                else:
-                    measure_record = Measurement(setting=setting, error=frequency_or_error)
-                    measurement['error'] = frequency_or_error
-                measure_record.save()
-                measurement['measured_at'] = measure_record.measured_at.isoformat()
-                measurements[channel].append(dict_to_camel(measurement))
+                measurement = self._measure_channel(channel)
+                measurements[channel].append(measurement)
             channel_layer = get_channel_layer()
             for channel, channel_measurements in measurements.items():
                 async_to_sync(channel_layer.group_send)(


### PR DESCRIPTION
This resolves #69.

I have modified the measurement scheme:

- Previously, the task handler conducts all messages, and then measures once.
- Now the task handler measures consecutively for 0.5 s (it is fixed currently, but if needed, I will make it editable later) after handling all messages.
- After all measurements, it sends the results to clients at _once_, so it could reduce the data acquisition latency. 