### PR TITLE
Implement DAC module

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,8 +15,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Configure PAT for GitHub
+      env:
+        GH_PAT: ${{ secrets.GH_PAT }}
       run: |
-        git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+        git config --global url."https://x-access-token:${{ env.GH_PAT }}@github.com/".insteadOf "https://github.com/"
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,6 +14,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Configure PAT for GitHub
+      run: |
+        git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ psycopg==3.2.*
 channels==4.2.*
 whitenoise==6.8.*
 pylablib==1.4.*
+pyserial==3.5
 camel-converter==4.0.*
 git+https://github.com/snu-quiqcl/qcodes-driver.git@2ce8309707cd60973580befb70b6dcd3afb832d8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ channels==4.2.*
 whitenoise==6.8.*
 pylablib==1.4.*
 camel-converter==4.0.*
+git+https://github.com/snu-quiqcl/qcodes-driver.git@2ce8309707cd60973580befb70b6dcd3afb832d8

--- a/wlm_server/pid/dac/base.py
+++ b/wlm_server/pid/dac/base.py
@@ -1,0 +1,48 @@
+"""Module for base class of DAC devices."""
+
+from abc import ABC, abstractmethod
+
+class BaseDAC(ABC):
+    """Base class for DAC devices.
+
+    Each DAC is associated with a single communication port (e.g. 'COM4').
+    The only required high-level operation is: set a voltage on a given channel.
+    """
+
+    def __init__(self, port: str):
+        """
+        Args:
+            port: See port property.
+        """
+        self._port = port
+        self._is_open: bool = False
+
+    @property
+    def port(self) -> str:
+        """Communication port identifier, e.g. 'COM4'."""
+        return self._port
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the DAC connection is open."""
+        return self._is_open
+
+    @abstractmethod
+    def open(self):
+        """Opens the DAC connection."""
+        self._is_open = True
+
+    @abstractmethod
+    def close(self):
+        """Closes the DAC connection."""
+        self._is_open = False
+
+    @abstractmethod
+    def set_voltage(self, channel: int, voltage: float):
+        """Sets the voltage on the target channel.
+
+        Args:
+            channel: Target channel.
+            voltage: Target voltage in V.
+        """
+        raise NotImplementedError

--- a/wlm_server/pid/dac/base.py
+++ b/wlm_server/pid/dac/base.py
@@ -30,12 +30,10 @@ class BaseDAC(ABC):
     @abstractmethod
     def open(self):
         """Opens the DAC connection."""
-        self._is_open = True
 
     @abstractmethod
     def close(self):
         """Closes the DAC connection."""
-        self._is_open = False
 
     @abstractmethod
     def set_voltage(self, channel: int, voltage: float):
@@ -45,4 +43,3 @@ class BaseDAC(ABC):
             channel: Target channel.
             voltage: Target voltage in V.
         """
-        raise NotImplementedError

--- a/wlm_server/pid/dac/dac8734.py
+++ b/wlm_server/pid/dac/dac8734.py
@@ -47,7 +47,7 @@ class DAC8734(BaseDAC):
 
     def set_voltage(self, channel: int, voltage: float):
         """Overridden."""
-        if not (0 <= channel < self.NUM_CHANNELS):
+        if not 0 <= channel < self.NUM_CHANNELS:
             print(f'Invalid channel: {channel}')
             return
         if voltage < self.MIN_V or voltage > self.MAX_V:

--- a/wlm_server/pid/dac/dac8734.py
+++ b/wlm_server/pid/dac/dac8734.py
@@ -54,7 +54,7 @@ class DAC8734(BaseDAC):
         if not 0 <= channel < self.NUM_CHANNELS:
             logger.warning(f'Invalid channel: {channel}')
             return
-        if voltage < self.MIN_V or voltage > self.MAX_V:
+        if not self.MIN_V <= voltage <= self.MAX_V:
             logger.warning(f'Voltage out of range: {voltage}')
             return
         code = self._volts_to_code(voltage)

--- a/wlm_server/pid/dac/dac8734.py
+++ b/wlm_server/pid/dac/dac8734.py
@@ -1,9 +1,13 @@
 """Module for DAC8734 controlled via an ArtyS7 FPGA."""
 
+import logging
+
 import serial
 from qcodes_driver.AD9912.ArtyS7 import ArtyS7
 
 from .base import BaseDAC
+
+logger = logging.getLogger(__name__)
 
 class DAC8734(BaseDAC):
     """DAC8734 controlled via an ArtyS7 FPGA.
@@ -27,19 +31,19 @@ class DAC8734(BaseDAC):
     def open(self):
         """Overridden."""
         if self._is_open:
-            print(f'DAC8734 on {self._port} is already open')
+            logger.warning(f'DAC8734 on {self._port} is already open')
             return
         try:
             self._fpga = ArtyS7(self._port)
         except serial.SerialException as e:
-            print(f'Failed to open DAC8734: {e}')
+            logger.error(f'Failed to open DAC8734: {e}')
         else:
             self._is_open = True
 
     def close(self):
         """Overridden."""
         if not self._is_open:
-            print(f'DAC8734 on {self._port} is not open')
+            logger.warning(f'DAC8734 on {self._port} is not open')
             return
         self._fpga.close()
         self._fpga = None
@@ -48,10 +52,10 @@ class DAC8734(BaseDAC):
     def set_voltage(self, channel: int, voltage: float):
         """Overridden."""
         if not 0 <= channel < self.NUM_CHANNELS:
-            print(f'Invalid channel: {channel}')
+            logger.warning(f'Invalid channel: {channel}')
             return
         if voltage < self.MIN_V or voltage > self.MAX_V:
-            print(f'Voltage out of range: {voltage}')
+            logger.warning(f'Voltage out of range: {voltage}')
             return
         code = self._volts_to_code(voltage)
         dac_number = channel // 4

--- a/wlm_server/pid/dac/dac8734.py
+++ b/wlm_server/pid/dac/dac8734.py
@@ -75,4 +75,4 @@ class DAC8734(BaseDAC):
             DAC code (0-65535).
         """
         raw = int((65536 / (4 * self.VREF)) * voltage)
-        return (raw + 65536) % 65536
+        return min(max(raw, 0), 65535)

--- a/wlm_server/pid/dac/dac8734.py
+++ b/wlm_server/pid/dac/dac8734.py
@@ -31,19 +31,19 @@ class DAC8734(BaseDAC):
     def open(self):
         """Overridden."""
         if self._is_open:
-            logger.warning(f'DAC8734 on {self._port} is already open')
+            logger.warning('DAC8734 on %s is already open', self._port)
             return
         try:
             self._fpga = ArtyS7(self._port)
         except serial.SerialException as e:
-            logger.error(f'Failed to open DAC8734: {e}')
+            logger.error('Failed to open DAC8734: %s', e)
         else:
             self._is_open = True
 
     def close(self):
         """Overridden."""
         if not self._is_open:
-            logger.warning(f'DAC8734 on {self._port} is not open')
+            logger.warning('DAC8734 on %s is not open', self._port)
             return
         self._fpga.close()
         self._fpga = None
@@ -52,10 +52,10 @@ class DAC8734(BaseDAC):
     def set_voltage(self, channel: int, voltage: float):
         """Overridden."""
         if not 0 <= channel < self.NUM_CHANNELS:
-            logger.warning(f'Invalid channel: {channel}')
+            logger.warning('Invalid channel: %d', channel)
             return
         if not self.MIN_V <= voltage <= self.MAX_V:
-            logger.warning(f'Voltage out of range: {voltage}')
+            logger.warning('Voltage out of range: %.4f V', voltage)
             return
         code = self._volts_to_code(voltage)
         dac_number = channel // 4

--- a/wlm_server/pid/dac/dac8734.py
+++ b/wlm_server/pid/dac/dac8734.py
@@ -1,0 +1,78 @@
+"""Module for DAC8734 controlled via an ArtyS7 FPGA."""
+
+import serial
+from qcodes_driver.AD9912.ArtyS7 import ArtyS7
+
+from .base import BaseDAC
+
+class DAC8734(BaseDAC):
+    """DAC8734 controlled via an ArtyS7 FPGA.
+    
+    Constants:
+        NUM_CHANNELS: Number of channels on the DAC8734.
+        VREF: Reference voltage for voltage-to-code conversion in V.
+        MIN_V: Minimum allowed output voltage in V.
+        MAX_V: Maximum allowed output voltage in V.
+    """
+
+    NUM_CHANNELS = 8
+    VREF = 2.5
+    MIN_V, MAX_V = 0, 2.5
+
+    def __init__(self, port: str):
+        """Extended."""
+        super().__init__(port)
+        self._fpga: ArtyS7 | None = None
+
+    def open(self):
+        """Overridden."""
+        if self._is_open:
+            print(f'DAC8734 on {self._port} is already open')
+            return
+        try:
+            self._fpga = ArtyS7(self._port)
+        except serial.SerialException as e:
+            print(f'Failed to open DAC8734: {e}')
+        else:
+            self._is_open = True
+
+    def close(self):
+        """Overridden."""
+        if not self._is_open:
+            print(f'DAC8734 on {self._port} is not open')
+            return
+        self._fpga.close()
+        self._fpga = None
+        self._is_open = False
+
+    def set_voltage(self, channel: int, voltage: float):
+        """Overridden."""
+        if not (0 <= channel < self.NUM_CHANNELS):
+            print(f'Invalid channel: {channel}')
+            return
+        if voltage < self.MIN_V or voltage > self.MAX_V:
+            print(f'Voltage out of range: {voltage}')
+            return
+        code = self._volts_to_code(voltage)
+        dac_number = channel // 4
+        dac_channel = channel % 4
+        self._fpga.send_mod_BTF_int_list([
+            1 << dac_number,
+            0x04 + dac_channel,
+            code // 256,
+            code % 256,
+        ])
+        self._fpga.send_command('WRITE REG')
+        self._fpga.send_command('LDAC')
+
+    def _volts_to_code(self, voltage: float) -> int:
+        """Converts voltage to DAC code.
+        
+        Args:
+            voltage: Target voltage in V.
+        
+        Returns:
+            DAC code (0-65535).
+        """
+        raw = int((65536 / (4 * self.VREF)) * voltage)
+        return (raw + 65536) % 65536

--- a/wlm_server/pid/dac/manager.py
+++ b/wlm_server/pid/dac/manager.py
@@ -76,5 +76,6 @@ class DacManager:
         """Closes all DAC instances."""
         with self._lock:
             for dac in self._instances.values():
-                dac.close()
+                if dac.is_open:
+                   dac.close()
             self._instances.clear()

--- a/wlm_server/pid/dac/manager.py
+++ b/wlm_server/pid/dac/manager.py
@@ -77,5 +77,5 @@ class DacManager:
         with self._lock:
             for dac in self._instances.values():
                 if dac.is_open:
-                   dac.close()
+                    dac.close()
             self._instances.clear()

--- a/wlm_server/pid/dac/manager.py
+++ b/wlm_server/pid/dac/manager.py
@@ -1,0 +1,80 @@
+"""Module for registry of DAC devices."""
+
+import threading
+from typing import Dict, Tuple, Type
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from .base import BaseDAC
+
+def get_dac_class(backend_alias: str) -> Type[BaseDAC]:
+    """Looks up DAC driver class from settings.DAC_BACKENDS.
+    
+    Args:
+        backend_alias: Alias of the DAC device defined in settings.DAC_BACKENDS.
+    
+    Returns:
+        DAC driver class. if not found, raises ValueError.
+    """
+    try:
+        path = settings.DAC_BACKENDS[backend_alias]
+    except KeyError as e:
+        raise ValueError(f'Unknown DAC backend alias: {backend_alias}') from e
+    return import_string(path)
+
+
+class DacManager:
+    """Manager for DAC instances.
+    
+    Keys: (backend_alias, port)
+    Values: DAC instance
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._instances: Dict[Tuple[str, str], BaseDAC] = {}
+    
+    def get_or_open(self, backend_alias: str, port: str) -> BaseDAC:
+        """Gets existing DAC instance for (backend_alias, port), or creates one.
+
+        Args:
+            backend_alias: See get_dac_class().
+            port: See BaseDAC.port.
+
+        Returns:
+            The DAC instance.
+        """
+        key = (backend_alias, port)
+        with self._lock:
+            dac = self._instances.get(key)
+            if dac is not None:
+                return dac
+            DacClass = get_dac_class(backend_alias)
+            dac = DacClass(port)
+            dac.open()
+            self._instances[key] = dac
+            return dac
+
+    def close(self, backend_alias: str, port: str):
+        """Closes the DAC instance for (backend_alias, port).
+        
+        Args:
+            backend_alias: See get_dac_class().
+            port: See BaseDAC.port.
+        """
+        key = (backend_alias, port)
+        with self._lock:
+            dac = self._instances.get(key)
+            if dac is None:
+                print(f'DAC instance for (backend_alias, port) not found: {key}')
+                return
+            dac.close()
+            del self._instances[key]
+
+    def close_all(self):
+        """Closes all DAC instances."""
+        with self._lock:
+            for dac in self._instances.values():
+                dac.close()
+            self._instances.clear()

--- a/wlm_server/pid/dac/manager.py
+++ b/wlm_server/pid/dac/manager.py
@@ -34,7 +34,7 @@ class DacManager:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._instances: Dict[Tuple[str, str], BaseDAC] = {}
-    
+
     def get_or_open(self, backend_alias: str, port: str) -> BaseDAC:
         """Gets existing DAC instance for (backend_alias, port), or creates one.
 
@@ -50,8 +50,8 @@ class DacManager:
             dac = self._instances.get(key)
             if dac is not None:
                 return dac
-            DacClass = get_dac_class(backend_alias)
-            dac = DacClass(port)
+            dac_class = get_dac_class(backend_alias)
+            dac = dac_class(port)
             dac.open()
             self._instances[key] = dac
             return dac

--- a/wlm_server/wlm_server/settings/base.py
+++ b/wlm_server/wlm_server/settings/base.py
@@ -180,7 +180,7 @@ LOCK_LOCK = threading.Lock()
 # DAC
 
 DAC_BACKENDS = {
-    'dac8734': 'pid.dac.dac8734.DAC8734',
+    'DAC8734': 'pid.dac.dac8734.DAC8734',
 }
 
 DAC_MANAGER = DacManager()

--- a/wlm_server/wlm_server/settings/base.py
+++ b/wlm_server/wlm_server/settings/base.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from decouple import Config, RepositoryEnv
 
 from task.message import MessageQueue
+from pid.dac.manager import DacManager
 from pid.message import PidMessageQueue
 from pid.dac_control import DacControlQueue
 from pid.frequency import FrequencyQueue
@@ -174,3 +175,12 @@ CHANNEL_CACHE = None
 
 TASK_LOCK = threading.Lock()
 LOCK_LOCK = threading.Lock()
+
+
+# DAC
+
+DAC_BACKENDS = {
+    'dac8734': 'pid.dac.dac8734.DAC8734',
+}
+
+DAC_MANAGER = DacManager()


### PR DESCRIPTION
This resolves #60.

I dropped Python 3.10 support because `qcodes-driver` requires NumPy versions that are not compatible with Python 3.10.